### PR TITLE
PLAT-332 Update buildkite bootstrap to use github

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ script when they start.
 1. **SSH Fingerprint verification** By default, when Buildkite checks out a git
    repository it automatically accept any SSH fingerprint without verifying its
    authenticity. This leaves the agent vulnerable to man-in-the-middle-attacks
-   in which another server could pretend to be bitbucket and provide the build
+   in which another server could pretend to be github and provide the build
    agent with hostile code to execute. To prevent this the bootstrapping script
-   disables automatic fingerprint verification and installs bitbucket's
+   disables automatic fingerprint verification and installs github's
    authentic fingerprint (pulled from their documentation). Since this is the
    only git provider we expect to access, there is no need to allow any other
    fingerprints.

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -5,7 +5,7 @@ set -eu
 sudo yum install -y ruby23
 
 ## Clone buildkite-assets
-git clone https://bitbucket.org/panoramaed/buildkite-assets.git
+git clone https://github.com/panorama-ed/buildkite-assets.git
 
 ## Go into the cloned repository directory
 cd buildkite-assets
@@ -29,20 +29,29 @@ EOF
 
 #############################################################################
 # Require SSH fingerprint verification to prevent MITM attacks (e.g. someone
-# pretending to be bitbucket)
+# pretending to be github)
 #############################################################################
 cat <<EOF >> /etc/buildkite-agent/buildkite-agent.cfg
 no-automatic-ssh-fingerprint-verification=true
 EOF
 
 #############################################################################
-# Write out the bitbucket known SSH fingerprint so that we can clone from
+# Write out the github known SSH fingerprint so that we can clone from
 # our repositories without getting asked for user entry.
 #############################################################################
 AGENT_HOME=`getent passwd buildkite-agent | cut -d: -f6`
 mkdir -p $AGENT_HOME/.ssh
-cat <<BITBUCKET_KNOWN_HOST > $AGENT_HOME/.ssh/known_hosts
-bitbucket.org,104.192.143.1 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAubiN81eDcafrgMeLzaFPsw2kNvEcqTKl/VqLat/MaB33pZy0y3rJZtnqwR2qOOvbwKZYKiEO1O6VqNEBxKvJJelCq0dTXWT5pbO2gDXC6h6QDXCaHo6pOHGPUy+YBaGQRGuSusMEASYiWunYN0vCAI8QaXnWMXNMdFP3jHAJH0eDsoiGnLPBlBp4TNm6rYI74nMzgz3B9IikW4WVK+dc8KZJZWYjAuORU3jc1c/NPskD2ASinf8v3xnfXeukU0sJ5N6m5E8VLjObPEO+mN2t/FZTMZLiFqPWc/ALSqnMnnhwrNi2rbfg/rd/IpL8Le3pSBne8+seeFVBoGqzHM9yXw==
-BITBUCKET_KNOWN_HOST
+
+cat <<GITHUB_KNOWN_HOST > $AGENT_HOME/.ssh/known_hosts
+# The GitHub public key is obtained by running `ssh -T git@github.com`,
+# confirming that the fingerprint matches GitHub's published fingerprint
+# (see: https://help.github.com/articles/github-s-ssh-key-fingerprints/),
+# and then pulling the added line out of the local `known_hosts` file. We do
+# not specify a given IP address for GitHub because GitHub uses many IP
+# addresses and regularly changes them
+# (see: https://help.github.com/articles/about-github-s-ip-addresses/).
+github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==
+GITHUB_KNOWN_HOST
+
 chown buildkite-agent: $AGENT_HOME/.ssh
 chown buildkite-agent: $AGENT_HOME/.ssh/known_hosts

--- a/check_command_whitelist.rb
+++ b/check_command_whitelist.rb
@@ -7,7 +7,7 @@
 
 require "yaml"
 
-KNOWN_REPOSITORY_PREFIX = "git@bitbucket.org:panoramaed/"
+KNOWN_REPOSITORY_PREFIX = "git@github.com:panorama-ed/"
 
 # This command allows us to upload and process the pipeline file from our
 # repositories

--- a/spec/check_command_whitelist_spec.rb
+++ b/spec/check_command_whitelist_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "Pre-command Hook" do
     }
   end
 
-  let(:repo) { "git@bitbucket.org:panoramaed/forklift.git" }
+  let(:repo) { "git@github.com:panorama-ed/forklift.git" }
   let(:repo_path) { Dir.mktmpdir }
   let(:command) { "echo Hello World!" }
   let(:buildkite_command) { command }
@@ -75,7 +75,7 @@ RSpec.describe "Pre-command Hook" do
       end
 
       context "when the repository is not allowed" do
-        let(:repo) { "git@bitbucket.org:somehwere_malicious/rainbow.git" }
+        let(:repo) { "git@github.com:somehwere_malicious/rainbow.git" }
 
         it "fails with a reasonable message" do
           expect(subject[:status]).to eq(4), "Expected script to fail"


### PR DESCRIPTION
This updates the repository to use github to pull and build the buildkite agents.

A follow-on action to this will be to modify the cloudformation script to point to github and not to bitbucket.