### PR TITLE
INFRA-2408-set-up-aws-cli

### DIFF
--- a/buildkite/pipeline.yml
+++ b/buildkite/pipeline.yml
@@ -1,3 +1,5 @@
 steps:
   - label: Test pre-command hook script
     command: ./buildkite/run_check_command_whitelist_tests.sh
+  - label: Test heroku-deploy Docker build
+    command: ./buildkite/run_check_deploy_docker_build.sh

--- a/buildkite/run_check_deploy_docker_build.sh
+++ b/buildkite/run_check_deploy_docker_build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# This script checks that the image from the heroku-deploy Dockerfile can be
+# built successfully. This check is done in the buildkite-assets repo to prevent
+# an unbuildable Dockerfile from being deployed to buildkite instances.
+
+DOCKER_IMAGE_NAME=check-heroku-deploy-image
+
+echo "--- Running heroku-deploy build"
+docker build \
+  --build-arg buildkite_agent_uid=$UID \
+  -t $DOCKER_IMAGE_NAME /usr/local/bin/heroku-deploy > build_results.out
+
+EXIT_STATUS=$?
+
+if [ $EXIT_STATUS -ne 0 ]; then
+  echo "+++ Build Results"
+else
+  echo "--- Build Results"
+fi
+cat build_results.out
+
+exit $EXIT_STATUS

--- a/deploy/heroku-deploy/Dockerfile
+++ b/deploy/heroku-deploy/Dockerfile
@@ -13,6 +13,11 @@ RUN curl -fsSLO https://download.docker.com/linux/static/stable/x86_64/docker-${
 # see installation instructions: https://devcenter.heroku.com/articles/heroku-cli#standalone-installation
 RUN curl https://cli-assets.heroku.com/install-standalone.sh | sh
 
+# Install AWS CLI. Secrets should be configured in the S3 bucket that Buildkite uses
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
+    && unzip awscliv2.zip \
+    && ./aws/install
+
 # Here, we take the UID for the user we will use in the docker image.
 # We do this so that we can map it to the user that built the docker image,
 # so file permissions will work inside the container.

--- a/deploy/panorama_command.sh
+++ b/deploy/panorama_command.sh
@@ -50,6 +50,9 @@ docker run \
   -e DEPLOYMENT_APP_NAME \
   -e HEROKU_DEPLOYMENT_LOGIN \
   -e HEROKU_DEPLOYMENT_API_KEY \
+  -e AWS_ACCESS_KEY_ID \
+  -e AWS_SECRET_ACCESS_KEY \
+  -e AWS_DEFAULT_REGION \
   -e BUILDKITE_COMMIT \
   -v `pwd`:/home/panorama/app \
   -v /var/run/docker.sock:/var/run/docker.sock \


### PR DESCRIPTION
This change introduces the ability to run AWS CLI commands from the Docker container that Buildkite instances build and run to execute Heroku deployment steps.

The PGP key for the aws cli is public, so if any changes to this file occur, builds in this repo will not pass. I added a script to test the `heroku-deploy` Docker build. Without this script, we would deploy code to Buildkite EC2 instances where the `panorama_command.sh` script would try to build the `heroku-deploy` image and fail.

### Manual Tests
1. Verified that building the `heroku-deploy` Docker image locally was successful
2. Modified `aws_cli_public_pgp_key.text` to be invalid to verify that building the heroku-deploy Docker image would throw an error (which would fail a Buildkite build since this test is listed in `pipeline.yml`)