### PR TITLE
SCALE-56 Mute AWS CLI unzip

### DIFF
--- a/deploy/heroku-deploy/Dockerfile
+++ b/deploy/heroku-deploy/Dockerfile
@@ -15,7 +15,7 @@ RUN curl https://cli-assets.heroku.com/install-standalone.sh | sh
 
 # Install AWS CLI. Secrets should be configured in the S3 bucket that Buildkite uses
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
-    && unzip awscliv2.zip \
+    && unzip -qq awscliv2.zip \
     && ./aws/install
 
 # Here, we take the UID for the user we will use in the docker image.


### PR DESCRIPTION
https://panoramaed.atlassian.net/browse/SCALE-56

[This line](https://github.com/panorama-ed/buildkite-assets/blob/main/deploy/heroku-deploy/Dockerfile#L18) seems to produce a truly huge amount of output as it [announces every file included in the AWS CLI](https://buildkite.com/panorama-education/nds/builds/75391#0182a8b2-4cda-486e-986e-825afb0a154f/6-12), which is making our Buildkite logs pretty unwieldy.