### PR TITLE
INFRA-2451: Add Terraform to bootstrap.sh

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -4,6 +4,10 @@ set -eu
 ## Make sure we'll use ruby 2.6
 amazon-linux-extras install -y ruby2.6
 
+## Install Terraform
+curl "https://releases.hashicorp.com/terraform/1.2.7/terraform_1.2.7_linux_amd64.zip" -o "terraform.zip" \
+sudo unzip ./terraform.zip –d /usr/local/bin
+
 ## Clone buildkite-assets
 git clone https://github.com/panorama-ed/buildkite-assets.git
 


### PR DESCRIPTION
Adds terraform install commands to bootstrap.sh. This was tested by installing buildkite-agent and running locally with bootstrap command. The bootstrap file is run when the repo is cloned, and therefore whatever is on main is what is run. To test that my local changes worked I created another repo buildkite-assets-test that was copied from buildkite-assets, changed the bootstrap file on main, and used the bootstrap command to use the test repo instead of the original buildkite-assets repo.