### PR TITLE
INFRA-2451: Remove bootstrap backslash

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -4,6 +4,10 @@ set -eu
 ## Make sure we'll use ruby 2.6
 amazon-linux-extras install -y ruby2.6
 
+## Install Terraform
+curl "https://releases.hashicorp.com/terraform/1.2.7/terraform_1.2.7_linux_amd64.zip" -o "terraform.zip" 
+sudo unzip ./terraform.zip -d /usr/local/bin
+
 ## Clone buildkite-assets
 git clone https://github.com/panorama-ed/buildkite-assets.git
 


### PR DESCRIPTION
Attempt 2 to get terraform installed. It looks like a backslash may have been causing the problem in the curl command. Tested by sshing into a buildkite agent an running the commands. It is possible this could still fail when run on an EC2 instance but no way of testing without pushing to main. Will watch buildkite instances and see if they start failing once this is merged. If so, will immediately revert.