### PR TITLE
INFRA-2483 remove aws cli from Buildkite agents

### DIFF
--- a/deploy/heroku-deploy/Dockerfile
+++ b/deploy/heroku-deploy/Dockerfile
@@ -13,11 +13,6 @@ RUN curl -fsSLO https://download.docker.com/linux/static/stable/x86_64/docker-${
 # see installation instructions: https://devcenter.heroku.com/articles/heroku-cli#standalone-installation
 RUN curl https://cli-assets.heroku.com/install-standalone.sh | sh
 
-# Install AWS CLI. Secrets should be configured in the S3 bucket that Buildkite uses
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
-    && unzip -qq awscliv2.zip \
-    && ./aws/install
-
 # Here, we take the UID for the user we will use in the docker image.
 # We do this so that we can map it to the user that built the docker image,
 # so file permissions will work inside the container.

--- a/deploy/panorama_command.sh
+++ b/deploy/panorama_command.sh
@@ -50,9 +50,6 @@ docker run \
   -e DEPLOYMENT_APP_NAME \
   -e HEROKU_DEPLOYMENT_LOGIN \
   -e HEROKU_DEPLOYMENT_API_KEY \
-  -e AWS_ACCESS_KEY_ID \
-  -e AWS_SECRET_ACCESS_KEY \
-  -e AWS_DEFAULT_REGION \
   -e BUILDKITE_COMMIT \
   -v `pwd`:/home/panorama/app \
   -v /var/run/docker.sock:/var/run/docker.sock \


### PR DESCRIPTION
This change essentially reverts [INFRA-2408](https://github.com/panorama-ed/buildkite-assets/pull/153) which installed the AWS CLI in the nested Docker container that the panorama_command script spins up to run secure commands. We no longer need this CLI here since we opted to use the ECR Buildkite addon to push parser images. This change also includes updating the file in the buildkite-runners AWS Account's S3 bucket (not shown in this code change, but will be a follow-up).