### PR TITLE
Revert "SCALE-240 Move to Ruby 3.1.3"

### DIFF
--- a/.overcommit/Gemfile.lock
+++ b/.overcommit/Gemfile.lock
@@ -76,4 +76,4 @@ DEPENDENCIES
   panolint!
 
 BUNDLED WITH
-   2.3.26
+   1.17.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-FROM ruby:3.1.3
+FROM ruby:2.7.6
+
+ARG BUNDLER_VERSION=1.17.3
+
+RUN gem install bundler --version "$BUNDLER_VERSION" --no-document
 
 COPY ./ ./
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,4 +23,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   2.3.26
+   1.17.3

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -eu
 
-## Make sure we'll use ruby 3.1
-amazon-linux-extras install -y ruby3.1
+## Make sure we'll use ruby 2.6
+amazon-linux-extras install -y ruby2.6
 
 ## Install Terraform
 curl "https://releases.hashicorp.com/terraform/1.2.7/terraform_1.2.7_linux_amd64.zip" -o "terraform.zip" 

--- a/buildkite/run_check_deploy_docker_build.sh
+++ b/buildkite/run_check_deploy_docker_build.sh
@@ -4,10 +4,20 @@
 # built successfully. This check is done in the buildkite-assets repo to prevent
 # an unbuildable Dockerfile from being deployed to buildkite instances.
 
-echo "--- Building and testing with panorama_command.sh"
-HEROKU_DEPLOY_PATH=deploy/heroku-deploy \
-  HEROKU_DEPLOY_IMAGE_NAME=check-heroku-deploy-image \
-  DEPLOYMENT_APP_NAME=panorama-addons \
-  bash deploy/panorama_command.sh custom
+DOCKER_IMAGE_NAME=check-heroku-deploy-image
 
-exit $?
+echo "--- Running heroku-deploy build"
+docker build \
+  --build-arg buildkite_agent_uid=$UID \
+  -t $DOCKER_IMAGE_NAME /usr/local/bin/heroku-deploy > build_results.out
+
+EXIT_STATUS=$?
+
+if [ $EXIT_STATUS -ne 0 ]; then
+  echo "+++ Build Results"
+else
+  echo "--- Build Results"
+fi
+cat build_results.out
+
+exit $EXIT_STATUS

--- a/deploy/heroku-deploy/Dockerfile
+++ b/deploy/heroku-deploy/Dockerfile
@@ -1,8 +1,8 @@
-FROM ruby:3.1.3
+FROM heroku/heroku:18
 
 # Install Docker client, which is used by Heroku CLI for container release
 # see installation instructions: https://docs.docker.com/install/linux/docker-ce/binaries/
-ENV DOCKERVERSION=20.10.9
+ENV DOCKERVERSION=18.03.1-ce
 RUN curl -fsSLO https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKERVERSION}.tgz \
   && mv docker-${DOCKERVERSION}.tgz docker.tgz \
   && tar xzvf docker.tgz \
@@ -23,7 +23,7 @@ RUN useradd -u $buildkite_agent_uid -m panorama
 
 # Make the platform API gem available to ruby scripts run inside the container.
 # Useful for scripting things like environment variable updates
-RUN gem install platform-api --no-document
+RUN gem install platform-api --no-rdoc --no-ri --version "2.1.0"
 
 WORKDIR /home/panorama
 

--- a/deploy/heroku-deploy/README.md
+++ b/deploy/heroku-deploy/README.md
@@ -20,7 +20,7 @@ To use this image, just build it and run your deploy commands.
 docker build \
   --build-arg buildkite_agent_uid=$UID \
   -t heroku-deploy-img \
-  deploy/heroku-deploy
+  buildkite/heroku-deploy
 ```
 
 ## Run It :rocket:

--- a/deploy/panorama_command.sh
+++ b/deploy/panorama_command.sh
@@ -25,7 +25,7 @@ export HEROKU_DEPLOY_PATH=${HEROKU_DEPLOY_PATH:=/usr/local/bin/heroku-deploy}
 # Build docker image
 docker build \
   --build-arg buildkite_agent_uid=$UID \
-  -t ${HEROKU_DEPLOY_IMAGE_NAME:=heroku-deploy-img} \
+  -t heroku-deploy-img \
   $HEROKU_DEPLOY_PATH
 
 command=""
@@ -53,5 +53,5 @@ docker run \
   -e BUILDKITE_COMMIT \
   -v `pwd`:/home/panorama/app \
   -v /var/run/docker.sock:/var/run/docker.sock \
-  -it ${HEROKU_DEPLOY_IMAGE_NAME:=heroku-deploy-img} \
+  -it heroku-deploy-img \
   $command


### PR DESCRIPTION
https://panoramaed.atlassian.net/browse/SCALE-283

This reverts commit 643dde04161a897059b67642a3a4330a7c11a9e1.

Agents are failing to start, because `ruby3.1` isn't recognized by `amazon-linux-extras` in `bootstrap.sh`. Reverting for now, to be followed by an updated version of SCALE-240 that fixes the issue.