### PR TITLE
SCALE-785 Install Kubectl and Helm CLIs

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
 set -eu
 
-KUBECTL_VERSION=v1.24.15
+KUBECTL_VERSION=v1.24.16
 HELM_VERSION=v3.12.2
 
 ## Make sure we have Ruby 3 installed directly on the instance
-#amazon-linux-extras install -y ruby3.0
-dnf install -y ruby
+yum install -y ruby
 
 # Install Kubectl and Helm CLIs
 wget -q https://dl.k8s.io/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -7,6 +7,10 @@ HELM_VERSION=v3.12.2
 ## Make sure we have Ruby 3 installed directly on the instance
 yum install -y ruby
 
+## Install Terraform
+curl "https://releases.hashicorp.com/terraform/1.5.4/terraform_1.5.4_linux_amd64.zip" -o "terraform.zip"
+sudo unzip ./terraform.zip -d /usr/local/bin
+
 # Install Kubectl and Helm CLIs
 wget -q https://dl.k8s.io/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl
 wget -q https://get.helm.sh/helm-$HELM_VERSION-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,12 +1,17 @@
 #!/bin/bash
 set -eu
 
-## Make sure we have Ruby 3 installed directly on the instance
-amazon-linux-extras install -y ruby3.0
+KUBECTL_VERSION=v1.24.15
+HELM_VERSION=v3.12.2
 
-## Install Terraform
-curl "https://releases.hashicorp.com/terraform/1.2.7/terraform_1.2.7_linux_amd64.zip" -o "terraform.zip"
-sudo unzip ./terraform.zip -d /usr/local/bin
+## Make sure we have Ruby 3 installed directly on the instance
+#amazon-linux-extras install -y ruby3.0
+dnf install -y ruby
+
+# Install Kubectl and Helm CLIs
+wget -q https://dl.k8s.io/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl
+wget -q https://get.helm.sh/helm-$HELM_VERSION-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm
+chmod +x /usr/local/bin/helm /usr/local/bin/kubectl
 
 ## Clone buildkite-assets
 git clone https://github.com/panorama-ed/buildkite-assets.git


### PR DESCRIPTION
This change includes kubectl and helm CLIs in the bootstrap script for Buildkite instances.
**Author confirmed the following:**
- [x] After pointing Buildkite instances to this bootstrap script, author could run kubectl and helm commands in an SSM Session for a Buildkite EC2 instance.