### PR TITLE
SECZ-1999: Setup VPC Peering in VDI Sandbox

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -27,6 +27,9 @@ pip install ansible
 ## Install Boto3
 pip install boto3
 
+## Install Ruby SDK for AWS Directory Data API Services
+gem install aws-sdk-directoryservicedata
+
 ## Install Terraform
 curl "https://releases.hashicorp.com/terraform/1.5.4/terraform_1.5.4_linux_${ARCH}.zip" -o "terraform.zip"
 sudo unzip ./terraform.zip -d /usr/local/bin


### PR DESCRIPTION
- Installing gem that allows us to use the AWS Directory Data Services api which allows the buildkite agents to create users in the AWS Managed Microsoft AD for provisioning new VDI workspaces