### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dependabot-prs.yml
+++ b/.github/workflows/dependabot-prs.yml
@@ -1,4 +1,7 @@
 name: Dependabot Pull Request
+permissions:
+  contents: read
+  pull-requests: write
 on:
   pull_request_target:
     types: [opened, synchronize, reopened, labeled]


### PR DESCRIPTION
Potential fix for [https://github.com/panorama-ed/buildkite-assets/security/code-scanning/3](https://github.com/panorama-ed/buildkite-assets/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the permissions required. Based on the workflow's operations:
1. The `dependabot/fetch-metadata` action likely requires `contents: read` to fetch metadata about the repository.
2. The `gh pr merge` and `gh pr review` commands require `pull-requests: write` to approve and merge pull requests.

We will set these permissions explicitly and ensure no unnecessary write permissions are granted.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
