### PR TITLE
IOPZ-9017: Update bootstrap.sh to update packages securely and stream…

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -11,10 +11,22 @@ else
   ARCH="arm64"
 fi
 
+# Detect the OS once; reused by the update step and the Ruby install below.
+OS_VERSION=$(uname -a)
+
+# Refresh package metadata and upgrade installed packages so subsequent
+# installs pull the latest versions and security patches. On yum/dnf-based
+# distros `update` performs both the metadata refresh and the upgrade in
+# a single command (no separate `update` + `upgrade` pair like apt).
+if [[ $OS_VERSION =~ "amzn2023" ]]; then
+  dnf update -y --security
+else
+  yum update -y --security
+fi
+
 # Make sure we have Ruby 3 installed directly on the instance
 # on AL2 need to use `amazon-linux-extras` to install `ruby3.0`
 # AL2023 no longer has `amazon-linux-extras` so we use `dnf` to install ruby
-OS_VERSION=$(uname -a)
 if [[ $OS_VERSION =~ "amzn2023" ]]; then
   dnf install -y ruby
 else
@@ -26,10 +38,6 @@ pip install ansible
 
 ## Install Boto3
 pip install boto3
-
-## Install Terraform
-curl "https://releases.hashicorp.com/terraform/1.5.4/terraform_1.5.4_linux_${ARCH}.zip" -o "terraform.zip"
-sudo unzip ./terraform.zip -d /usr/local/bin
 
 ## Install OpenTofu 1.6.2
 curl -sL "https://github.com/opentofu/opentofu/releases/download/v1.6.2/tofu_1.6.2_linux_${ARCH}.zip" -o "tofu.zip"


### PR DESCRIPTION
Update bootstrap.sh to update packages securely and streamline Ruby installation on Amazon Linux 2023.  Removed Terraform installation steps.

Should help address:
IOPZ-9018, IOPZ-9021, IOPZ-9022, IOPZ-9023

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes instance bootstrap behavior by running OS security updates and adjusting Ruby install paths, which could affect build agent provisioning and dependency availability. Also removes Terraform installation, which may break workflows still expecting it.
> 
> **Overview**
> Updates `bootstrap.sh` to **run security-focused OS package updates** (`yum`/`dnf update --security`) before installing tooling, and reuses a single OS detection value for both updates and the Ruby install path (AL2023 uses `dnf install ruby`, AL2 uses `amazon-linux-extras`).
> 
> Removes the Terraform installation step, leaving OpenTofu as the IaC CLI installed by the bootstrap script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd227de3deecee1552ae96c90ac325d2aa88ba7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->